### PR TITLE
Remove "package-override" and replace it with "package-link"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can specify options by using one of these formats:
 
 ### Global options
 - ``string: target-dir``: The directory that you want to use with this CLI tool.
-- ``string: package-override``: A ``key:value`` pair, where ``key`` is the name of package you want to override and ``value`` is the package specifier (such as ``^1.0.0``, ``file:../package`` or ``git:mygitrepo``). Mainly used for testing packages.
+- ``string: package-link``: A ``key:value`` pair, where ``key`` is the name of package and ``value`` is the path to the local package that you want to use (instead of packages from npm registry).
 
 ### ``build`` options
 - ``boolean: clean``: Remove ``build/`` before build.
@@ -41,14 +41,14 @@ To handle the build process, we use something called "build configurations". The
 ```json
 {
     "type": "configuration",
-    "overrides": {
-        "@mixery/engine": "file:../engine",
-        "@mixery/uikit": "file:../uikit"
+    "links": {
+        "@mixery/engine": "../engine",
+        "@mixery/uikit": "../uikit"
     }
 }
 ```
 
-"``overrides``" field is used to replace modules from npm registry with our local copy.
+Here, we used ``"links"`` to link our local package (a.k.a packages in development) to generated npm module (which is generated in ``build/``).
 
 > Configuration created from ``mixerycli`` does _not_ contains "Mixery Essentials". If you want, you can clone [MixeryOSS/essentials](https://github.com/MixeryOSS/essentials) into ``addons/`` directory. See next section for details.
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "node .",
+    "build": "tsc -b",
     "build:watch": "tsc -w"
   },
   "files": [

--- a/src/system/MixeryConfigView.ts
+++ b/src/system/MixeryConfigView.ts
@@ -113,9 +113,11 @@ export class MixeryConfigView extends FileSystemView {
             return;
         }
 
-        if (logging) Logger.stage("Running 'npm install'...");
-        await installPackages(this.file("build"));
-        
+        if (!fs.existsSync(this.file("build/node_modules"))) {
+            if (logging) Logger.stage("Installing npm packages...");
+            await installPackages(this.file("build"));
+        }
+
         if (logging) Logger.stage("Running esbuild...");
         await esbuild.build({
             bundle: true,

--- a/src/system/MixeryJson.ts
+++ b/src/system/MixeryJson.ts
@@ -1,10 +1,9 @@
-import { PackageOverrides } from "..";
 import { AddonJson } from "./AddonView";
 import { MixeryConfigJson } from "./MixeryConfigView";
 
 export interface MixeryJson<TType extends string> {
     type: TType;
-    overrides?: PackageOverrides;
+    links?: Record<string, string>;
 }
 
 export type MixeryJsonAny = MixeryConfigJson | AddonJson;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,14 @@
+import * as childProcess from "node:child_process";
+
+export async function runCommand(command: string, cwd = ".") {
+    await new Promise((resolve, reject) => {
+        let proc = childProcess.exec(command, { cwd });
+        proc.stdout.pipe(process.stdout);
+        proc.stderr.pipe(process.stderr);
+        proc.on("error", reject);
+        proc.on("exit", (code, signal) => {
+            if (code != 0) reject(new Error(`Program exited with code ${code}`));
+            else resolve(null);
+        });
+    });
+}


### PR DESCRIPTION
The new ``--package-link`` uses ``npm link`` to link local packages to addons or build directory, which allows us to make changes on different part of Mixery without needing to publish the package to npm registry:

```sh
mixerycli build --target-dir=daw --package-link=@mixery/engine:engine --package-link=@mixery/ui:ui
```

The value for ``key:value`` pair is now ``path/to/dir`` instead of package specifier.